### PR TITLE
fix Unable to find template resource: /liveTemplates/info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ patchPluginXml {
     sinceBuild = '222.0'
     changeNotes = """
     <ul>
-       <li>supported latest api grammar</li>
+       <li>fix Unable to find template resource: /liveTemplates/info</li>
     </ul>
     """
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2048m
 systemProp.http.proxyHost=127.0.0.1
 systemProp.http.proxyPort=1080
 antlr4Version = 4.10.1
-intellijVersion = 1.2.1
+intellijVersion = 1.2.2

--- a/src/main/java/cn/xiaoheiban/template/ApiLiveTemplatesProvider.java
+++ b/src/main/java/cn/xiaoheiban/template/ApiLiveTemplatesProvider.java
@@ -8,12 +8,12 @@ public class ApiLiveTemplatesProvider implements DefaultLiveTemplatesProvider {
 
     @Override
     public String[] getDefaultLiveTemplateFiles() {
-       return new String[]{"/liveTemplates/api", "/liveTemplates/apiTags", "/liveTemplates/info"};
+        return new String[]{"/liveTemplates/api", "/liveTemplates/apiTags"};
     }
 
     @Nullable
     @Override
-    public  String[] getHiddenLiveTemplateFiles() {
+    public String[] getHiddenLiveTemplateFiles() {
         return new String[]{"/liveTemplates/apiHidden"};
     }
 }


### PR DESCRIPTION
fix `Unable to find template resource: /liveTemplates/info`